### PR TITLE
docs: basic specification for core APIs, template engine and quick start guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NRAF
+![nraf logo](https://user-images.githubusercontent.com/63957920/149619576-3df47314-2d3e-4d50-8e12-da5bb4ab9b77.png)
 
 NRAF is an abbreviation, for "Not Really A Framework". I don't remember why I named it that in 2018, it's been a while, but I kinda like the sound of it, so the name stayed.
 
@@ -87,6 +87,14 @@ and this works, right out of the box.
 This means that, some amount of `express` code can directly be ported to `NRAF`, just by changing the imports.
 
 You can play with the Todo App example, using `node example/Todo/index.js`.
+
+## Documentaion
+
+Read more about `nraf`:
+
+- [Quick Start Guide](./docs/quick%20start.md)
+- [Core API specification](./docs/Core%20API.md)
+- [Template Engine specification](./docs/template%20engine.md)
 
 ## Examples
 

--- a/docs/Core API.md
+++ b/docs/Core API.md
@@ -1,0 +1,252 @@
+# Core API
+
+# NRAF()
+
+Creates a NRAF application. The `NRAF()` function is a top-level core function exported by the `@nraf/core` package.
+
+```javascript
+const NRAF = require("@nraf/core");
+const app = NRAF();
+```
+
+# Application
+
+The `app` object conventionally denotes the Nraf application. Create it by calling the top-level `NRAF()` function exported by the nraf/core module:
+
+```javascript
+var NRAF = require("@nraf/core");
+var app = NRAF();
+
+app.get("/", function (req, res) {
+  res.send("hello world");
+});
+
+app.listen(3000);
+```
+
+## app.set(name, value)
+
+Assigns setting `name` to `value`.
+
+The following table lists application settings:
+
+| Property | Type   | Description                                                                                               | Default |
+| -------- | ------ | --------------------------------------------------------------------------------------------------------- | ------- |
+| “views”  | String | Path of the folder containing the views, i.e. the .nraf extension files for the template-engine to parse. | null    |
+| “public” | String | Path of the folder containing public assets such as robots.txt, favicon, etc.                             | null    |
+
+NOTE: You must set the “views” & “public” directory path explicitly in your app. For more details, [read this](https://github.com/vipulbhj/vipulbhj/blob/main/blogs/LearningsWhileBuildingNRAF/TheCuriousCaseOfResDotRender/README.md).
+
+### Example:
+
+```javascript
+app.set("views", path.join(__dirname, "views"));
+app.set("public", path.join(__dirname, "public"));
+```
+
+## app.get(path, callback)
+
+Routes HTTP GET requests to the specified path with the specified callback functions.
+
+### Argument specification:
+
+| Argument | Description                                                                                    |
+| -------- | ---------------------------------------------------------------------------------------------- |
+| path     | A path for which the middleware function is invoked                                            |
+| callback | A callback function to be executed which takes the response and request objects as parameters. |
+
+### Example:
+
+```javascript
+app.get("/", (req, res) => {
+  res.json(todos);
+});
+```
+
+## app.post(path, callback)
+
+Routes HTTP POST requests to the specified path with the specified callback functions.
+
+### Argument specification:
+
+| Argument | Description                                                                                    |
+| -------- | ---------------------------------------------------------------------------------------------- |
+| path     | A path for which the middleware function is invoked                                            |
+| callback | A callback function to be executed which takes the response and request objects as parameters. |
+
+### Example:
+
+```javascript
+app.post("/add-todo", (req, res) => {
+  TODOS.push(req.body.todoContent);
+  res.redirect("/");
+});
+```
+
+## app.use(callback)
+
+Mounts the specified middleware function.
+
+### Example:
+
+```javascript
+app.use((req, res, next) => {
+  console.log("Time: %d", Date.now());
+  next();
+});
+```
+
+## app.listen(PORT, callback)
+
+This method is identical to Node’s [http.Server.listen()](https://nodejs.org/api/http.html#http_server_listen).
+
+### Example:
+
+```javascript
+const PORT = process.env.PORT || 3000;
+
+...
+...
+
+app.listen(PORT, () => {
+  console.log("Server is running on PORT: ", PORT);
+});
+```
+
+# Response
+
+## res.render(view, locals)
+
+Renders a view and sends the compiled HTML string to the client.
+
+The `view` argument is a string that is the file name of the view file to render.
+
+`locals` is an object whose properties define local variables for the view.
+
+NOTE: You should set the “views” directory path explicitly in your app. For more details, [read this](https://github.com/vipulbhj/vipulbhj/blob/main/blogs/LearningsWhileBuildingNRAF/TheCuriousCaseOfResDotRender/README.md).
+
+[Read more about the nraf template engine](./template%20engine.md).
+
+### Example:
+
+```javascript
+res.render("home", {
+  todos: TODOS,
+  isTodoEmpty: TODOS.length === 0,
+});
+```
+
+In the above example, `home` is the view passed which is same as the name of the file in the views directory.
+
+## res.redirect(path)
+
+Redirects to the URL derived from the specified `path`.
+
+It by default sets the HTTP status code to 302.
+
+### Example:
+
+```javascript
+res.redirect("/");
+```
+
+## res.json()
+
+Sends a JSON response. This method sends a response (with the correct content-type) that is the parameter converted to a JSON string using [JSON.stringify()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify).
+
+### Example:
+
+```javascript
+res.json({
+  idx,
+  content,
+});
+```
+
+## res.setStatus(statusCode)
+
+Sets the response HTTP status code to `statusCode`. If an unknown status code is specified, the response body will just be the code number.
+
+### Example:
+
+```javascript
+res.setStatus(302);
+```
+
+## res.send()
+
+This method is identical to Node’s [response.write()](https://nodejs.org/api/http.html#responsewritechunk-encoding-callback).
+
+### Example:
+
+```javascript
+res.send("<p>some html</p>");
+```
+
+## res.end()
+
+Ends the response process. This method comes from the [response.end() method of http.ServerResponse](https://nodejs.org/api/http.html#http_response_end_data_encoding_callback).
+
+### Example:
+
+```javascript
+res.end();
+```
+
+# Request
+
+## req.url
+
+The URL path on which a instance was mounted.
+
+### Example:
+
+```javascript
+app.get("/", (req, res) => {
+  console.log(req.query);
+  res.render("home", {
+    todos: TODOS,
+    isTodoEmpty: TODOS.length === 0,
+  });
+});
+
+// Console output: "/"
+```
+
+## req.body
+
+Contains key-value pairs of data submitted in the request body.
+
+### Example:
+
+```javascript
+app.post("/add-todo", (req, res) => {
+  TODOS.push(req.body.todoContent);
+  res.redirect("/");
+});
+```
+
+## req.params
+
+This property is a JS object containing properties mapped to the named route “parameters”. For example, if you have the route `/books/:bookId`, then the `bookID` property is available as `req.params.bookID`. This object defaults to `{}`.
+
+### Example:
+
+```javascript
+// Route path: /users/:userId/books/:bookId
+// Request URL: http://localhost:3000/users/34/books/8989
+
+req.params: { "userId": "34", "bookId": "8989" }
+```
+
+## req.query
+
+This property is a JS object after the query string is parsed. This object defaults to `{}`.
+
+### Example:
+
+```javascript
+// Route path: */user?name=tom&age=55*
+
+req.query: {name:"tom", age: "55"}
+```

--- a/docs/quick start.md
+++ b/docs/quick start.md
@@ -1,0 +1,94 @@
+# quick start
+
+## Installation
+
+This is a [Node.js](https://nodejs.org/en/) module available through the [npm registry](https://www.npmjs.com/).
+
+Before installing, [download and install Node.js](https://nodejs.org/en/download/).
+
+If this is a brand new project, make sure to create a `package.json` first with the [`npm init` command](https://docs.npmjs.com/creating-a-package-json-file).
+
+Installation is done using the [`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):
+
+```bash
+npm install @nraf/core
+```
+
+The above command installs the `@nraf/core` and the `@nraf/nte` templating engine packages.
+
+## Directory Setup
+
+Create 2 directories `views` and `public` and an `index.js` file in the root of the project. Or use the following command:
+
+```bash
+mkdir views
+mkdir public
+touch index.js
+```
+
+`views` directory would contain the `.nraf` template files.
+
+`public` directory would contain static files such as CSS, favicon, etc.
+
+## Running the project
+
+Paste the following code in the `index.js` file at the root of your project.
+
+```javascript
+const path = require("path");
+const NRAF = require("@nraf/core");
+
+const app = NRAF();
+const PORT = process.env.PORT || 3000;
+
+app.set("views", path.join(__dirname, "views"));
+app.set("public", path.join(__dirname, "public"));
+
+app.get("/", (req, res) => {
+  res.send("Hello World");
+});
+
+app.listen(PORT, () => {
+  console.log("Server is running on PORT: ", PORT);
+});
+```
+
+In the above code, we:
+
+- Import the necessary packages.
+- Set the directory paths for the `views` and `public` directories.
+- Create a route which responds with `Hello World`.
+
+NOTE: You must set the “views” & “public” directory path explicitly in your app. For more details, [read this](https://github.com/vipulbhj/vipulbhj/blob/main/blogs/LearningsWhileBuildingNRAF/TheCuriousCaseOfResDotRender/README.md).
+
+Run the following command in the terminal:
+
+```bash
+node index.js
+```
+
+You must see the following output in the terminal:
+
+![Terminal Output](https://user-images.githubusercontent.com/63957920/149618238-a2244e9c-d750-47e1-aa86-0f1415768643.png)
+
+View the website at: [http://localhost:3000](http://localhost:3000/)
+
+You will see the Hello World text on the page:
+
+![Webpage Output](https://user-images.githubusercontent.com/63957920/149618243-4b795edf-71a7-42da-9520-d20bf5e8001a.png)
+
+## Examples
+
+To view the examples, clone the nraf repo and install the dependencies:
+
+```bash
+git clone git@github.com:vipulbhj/nraf.git
+cd nraf
+npm install
+```
+
+Then run whichever example you want:
+
+```bash
+node examples/Todo/index.js
+```

--- a/docs/template engine.md
+++ b/docs/template engine.md
@@ -1,0 +1,72 @@
+# template engine
+
+A ***template engine*** enables you to use static template files in your application. At runtime, the template engine replaces variables in a template file with actual values, and transforms the template into an HTML file sent to the client. This approach makes it easier to design an HTML page.
+
+This is  `@nraf/nte` template language specification:
+
+# NRAF Template Language Specification:
+
+## Variable:
+
+A variable looks up a value from the template context. If you wanted to simply display a variable, you would do:
+
+```html
+{{ variable_name }}
+```
+
+## for:
+
+`for` iterates over arrays. Here, `items` is a JavaScript array:
+
+```html
+<ul>
+{% for item in items %}
+	<li>{{ item }}</li>
+{% endfor %}
+</ul>
+```
+
+The above example lists all the items in the `items` array.
+
+You can also get the array `index` of an item:
+
+```html
+<ul>
+{% for index item in items %}
+	<li>{{ index }}: {{ item }}</li>
+{% endfor %}
+</ul>
+```
+
+## if:
+
+`if` tests a condition and lets you selectively display content. It behaves exactly as JavaScript’s `if` behaves.
+
+```html
+{% if variable %}
+  It is true
+{% endif %}
+```
+
+If variable is defined and evaluates to true, "It is true" will be displayed. Otherwise, nothing will be.
+
+You can specify alternate conditions with `elif` and `else`:
+
+```html
+{% if hungry %}
+  I am hungry
+{% elif tired %}
+  I am tired
+{% else %}
+  I am good!
+{% endif %}
+```
+
+## Comments:
+
+You can write comments using `{#` and `#}`. Comments are completely stripped out when rendering.
+
+```html
+{# Loop through all the users #}
+{% for user in users %}...{% endfor %}
+```


### PR DESCRIPTION
This PR adds a Quick Start Guide, basic documentation for the NRAF Core API and the NRAF Template Engine as mentioned in #9.

# Screenshots

## Adds new Logo in the README
![Logo](https://user-images.githubusercontent.com/63957920/149620335-f58c827a-cd09-41c9-a8b3-48708e9ced52.png)

## Links for the Documentation in the README
![Documentation](https://user-images.githubusercontent.com/63957920/149620363-1248a7a3-4897-42c4-8897-72d8b46b743a.png)
